### PR TITLE
Move IO task into background to avoid StrictMode policy violation

### DIFF
--- a/android/src/main/kotlin/com/example/disk_space_2/DiskSpace_2Plugin.kt
+++ b/android/src/main/kotlin/com/example/disk_space_2/DiskSpace_2Plugin.kt
@@ -2,11 +2,15 @@ package com.example.disk_space_2
 
 import android.os.Environment
 import android.os.StatFs
+import android.os.Handler
+import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /** DiskSpace_2Plugin */
 class DiskSpace_2Plugin : FlutterPlugin, MethodCallHandler {
@@ -15,6 +19,8 @@ class DiskSpace_2Plugin : FlutterPlugin, MethodCallHandler {
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
   /// when the Flutter Engine is detached from the Activity
   private lateinit var channel: MethodChannel
+  private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+  private val mainHandler = Handler(Looper.getMainLooper())
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "disk_space_2")
@@ -23,12 +29,49 @@ class DiskSpace_2Plugin : FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(call: MethodCall, result: Result) {
     when (call.method) {
-      "getFreeDiskSpace" -> result.success(getFreeDiskSpace())
-      "getTotalDiskSpace" -> result.success(getTotalDiskSpace())
+      "getFreeDiskSpace" -> {
+        executor.execute {
+          try {
+            val diskSpace = getFreeDiskSpace()
+            mainHandler.post {
+              result.success(diskSpace)
+            }
+          } catch (e: Exception) {
+            mainHandler.post {
+              result.error("DISK_SPACE_ERROR", "Failed to get free disk space: ${e.message}", null)
+            }
+          }
+        }
+      }
+      "getTotalDiskSpace" -> {
+        executor.execute {
+          try {
+            val diskSpace = getTotalDiskSpace()
+            mainHandler.post {
+              result.success(diskSpace)
+            }
+          } catch (e: Exception) {
+            mainHandler.post {
+              result.error("DISK_SPACE_ERROR", "Failed to get total disk space: ${e.message}", null)
+            }
+          }
+        }
+      }
       "getFreeDiskSpaceForPath" -> {
         val path = call.argument<String>("path")
         if (path != null) {
-          result.success(getFreeDiskSpaceForPath(path))
+          executor.execute {
+            try {
+              val diskSpace = getFreeDiskSpaceForPath(path)
+              mainHandler.post {
+                result.success(diskSpace)
+              }
+            } catch (e: Exception) {
+              mainHandler.post {
+                result.error("DISK_SPACE_ERROR", "Failed to get free disk space for path: ${e.message}", null)
+              }
+            }
+          }
         } else {
           result.error("INVALID_ARGUMENT", "Path is required", null)
         }


### PR DESCRIPTION
Fix issuse:

```
StrictMode policy violation; ~duration=724 ms: android.os.strictmode.DiskReadViolation
at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1728)
at libcore.io.BlockGuardOs.statvfs(BlockGuardOs.java:426)
at libcore.io.ForwardingOs.statvfs(ForwardingOs.java:852)
at android.system.Os.statvfs(Os.java:909)
at android.os.StatFs.doStat(StatFs.java:51)
at android.os.StatFs.<init>(StatFs.java:43)
at com.example.disk_space_2.DiskSpace_2Plugin.getFreeDiskSpace(DiskSpace_2Plugin.kt:46)
at com.example.disk_space_2.DiskSpace_2Plugin.onMethodCall(DiskSpace_2Plugin.kt:26)
at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:267)
at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
at android.os.Handler.handleCallback(Handler.java:991)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loopOnce(Looper.java:232)
at android.os.Looper.loop(Looper.java:317)
at android.app.ActivityThread.main(ActivityThread.java:8934)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```

When enable strict policy:
```
StrictMode.setThreadPolicy(
                StrictMode.ThreadPolicy.Builder()
                    .detectAll()
                    .penaltyLog() 
                    .penaltyFlashScreen() 
                    .build()
```