### PR TITLE
fix: Linux Support

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(${PLUGIN_NAME} PRIVATE
   ${GTK_INCLUDE_DIRS}
 )
 
-target_compile_options(${PLUGIN_NAME} PRIVATE ${GTK_CFLAGS_OTHER})
+target_compile_options(${PLUGIN_NAME} PRIVATE ${GTK_CFLAGS} ${GTK_CFLAGS_OTHER})
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE
   flutter

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,49 +1,49 @@
-# The Flutter tooling requires that developers have CMake 3.10 or later
-# installed. You should not increase this version, as doing so will cause
-# the plugin to fail to compile for some customers of the plugin.
 cmake_minimum_required(VERSION 3.10)
 
-# Project-level configuration.
 set(PROJECT_NAME "disk_space_2")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-# This value is used when generating builds using this plugin, so it must
-# not be changed.
 set(PLUGIN_NAME "disk_space_2_plugin")
 
-# Any new source files that you add to the plugin should be added here.
+# Source files
 list(APPEND PLUGIN_SOURCES
   "disk_space_2_plugin.cc"
 )
 
-# Define the plugin library target. Its name must not be changed (see comment
-# on PLUGIN_NAME above).
+# Create the shared library
 add_library(${PLUGIN_NAME} SHARED
   ${PLUGIN_SOURCES}
 )
 
-# Apply a standard set of build settings that are configured in the
-# application-level CMakeLists.txt. This can be removed for plugins that want
-# full control over build settings.
+# Flutter standard settings
 apply_standard_settings(${PLUGIN_NAME})
 
-# Symbols are hidden by default to reduce the chance of accidental conflicts
-# between plugins. This should not be removed; any symbols that should be
-# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
+
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 
-# Source include directories and library dependencies. Add any plugin-specific
-# dependencies here.
+# Include plugin headers
 target_include_directories(${PLUGIN_NAME} INTERFACE
-  "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
-target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
 
-# List of absolute paths to libraries that should be bundled with the plugin.
-# This list could contain prebuilt libraries, or libraries created by an
-# external build triggered from this build file.
+# Link with flutter and GTK (if needed)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED gtk+-3.0)
+
+target_include_directories(${PLUGIN_NAME} PRIVATE
+  ${GTK_INCLUDE_DIRS}
+)
+
+target_compile_options(${PLUGIN_NAME} PRIVATE ${GTK_CFLAGS_OTHER})
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+  flutter
+  ${GTK_LIBRARIES}
+)
+
+# Bundled libraries placeholder
 set(disk_space_2_bundled_libraries
   ""
   PARENT_SCOPE

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,25 +1,49 @@
-cmake_minimum_required(VERSION 3.14)
+# The Flutter tooling requires that developers have CMake 3.10 or later
+# installed. You should not increase this version, as doing so will cause
+# the plugin to fail to compile for some customers of the plugin.
+cmake_minimum_required(VERSION 3.10)
+
+# Project-level configuration.
 set(PROJECT_NAME "disk_space_2")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
+# This value is used when generating builds using this plugin, so it must
+# not be changed.
+set(PLUGIN_NAME "disk_space_2_plugin")
 
+# Any new source files that you add to the plugin should be added here.
+list(APPEND PLUGIN_SOURCES
+  "disk_space_2_plugin.cc"
+)
+
+# Define the plugin library target. Its name must not be changed (see comment
+# on PLUGIN_NAME above).
 add_library(${PLUGIN_NAME} SHARED
-  "${PLUGIN_NAME}.cc"
+  ${PLUGIN_SOURCES}
 )
 
+# Apply a standard set of build settings that are configured in the
+# application-level CMakeLists.txt. This can be removed for plugins that want
+# full control over build settings.
+apply_standard_settings(${PLUGIN_NAME})
+
+# Symbols are hidden by default to reduce the chance of accidental conflicts
+# between plugins. This should not be removed; any symbols that should be
+# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
 set_target_properties(${PLUGIN_NAME} PROPERTIES
-  CXX_VISIBILITY_PRESET hidden
-  VERSION 1.0.0
-  SOVERSION 1
-)
-
+  CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Source include directories and library dependencies. Add any plugin-specific
+# dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
+# List of absolute paths to libraries that should be bundled with the plugin.
+# This list could contain prebuilt libraries, or libraries created by an
+# external build triggered from this build file.
 set(disk_space_2_bundled_libraries
   ""
   PARENT_SCOPE

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,38 +1,24 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "disk_space_2")
 project(${PROJECT_NAME} LANGUAGES CXX)
-
-# Add compiler warnings and optimizations
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  target_compile_options(${PROJECT_NAME} PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
-    -Werror=return-type
-    -O2
-  )
-endif()
 
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
-apply_standard_settings(${PLUGIN_NAME})
+
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VERSION 1.0.0
   SOVERSION 1
 )
+
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
-
-# Add documentation
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
-  DESTINATION "${CMAKE_INSTALL_DOCDIR}/${PROJECT_NAME}")
 
 set(disk_space_2_bundled_libraries
   ""


### PR DESCRIPTION
This pull request refactors the `linux/CMakeLists.txt` build configuration for the `disk_space_2` plugin, improving its structure and modernizing its integration with GTK and Flutter. The changes focus on separating plugin naming, organizing source files, updating how dependencies are handled, and removing unused or redundant configuration.

## Related Issues
- fixes #5 